### PR TITLE
Fix(Report): 리포트 API 생성 후 저장 로직 추가

### DIFF
--- a/src/main/generated/com/example/backend/model/QReport.java
+++ b/src/main/generated/com/example/backend/model/QReport.java
@@ -26,7 +26,9 @@ public class QReport extends EntityPathBase<Report> {
 
     public final NumberPath<Float> bsiIndex = createNumber("bsiIndex", Float.class);
 
-    public final QBusinessRegistration businessRegistrationId;
+    public final QBusinessRegistration businessRegistration;
+
+    public final StringPath content = createString("content");
 
     //inherited
     public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
@@ -47,6 +49,8 @@ public class QReport extends EntityPathBase<Report> {
     public final NumberPath<Long> reportId = createNumber("reportId", Long.class);
 
     public final DatePath<java.time.LocalDate> reportMonth = createDate("reportMonth", java.time.LocalDate.class);
+
+    public final StringPath reportType = createString("reportType");
 
     public final NumberPath<Long> revenue = createNumber("revenue", Long.class);
 
@@ -73,7 +77,7 @@ public class QReport extends EntityPathBase<Report> {
 
     public QReport(Class<? extends Report> type, PathMetadata metadata, PathInits inits) {
         super(type, metadata, inits);
-        this.businessRegistrationId = inits.isInitialized("businessRegistrationId") ? new QBusinessRegistration(forProperty("businessRegistrationId"), inits.get("businessRegistrationId")) : null;
+        this.businessRegistration = inits.isInitialized("businessRegistration") ? new QBusinessRegistration(forProperty("businessRegistration"), inits.get("businessRegistration")) : null;
     }
 
 }

--- a/src/main/java/com/example/backend/config/SecurityConfig.java
+++ b/src/main/java/com/example/backend/config/SecurityConfig.java
@@ -37,7 +37,7 @@ public class SecurityConfig {
                 .cors(cors -> cors.configurationSource(corsConfigurationSource())) // CORS 설정 추가
                 .authorizeRequests(auth -> auth
                         .requestMatchers("/api/auth/**").permitAll()  // 인증 및 회원가입 엔드포인트 접근 허용
-                        //.requestMatchers("/api/member/**").authenticated() // 회원 정보 수정은 인증된 사용자만 접근
+//                        .requestMatchers("/api/member/**").authenticated() // 회원 정보 수정은 인증된 사용자만 접근
                         .anyRequest().authenticated()  // 나머지 엔드포인트는 인증 필요
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(tokenProvider),
@@ -53,6 +53,7 @@ public class SecurityConfig {
 
         org.springframework.web.cors.CorsConfiguration configuration = new org.springframework.web.cors.CorsConfiguration();
         configuration.addAllowedOrigin("http://localhost:3000"); // 허용할 프론트엔드 도메인
+        configuration.addAllowedOrigin("http://localhost"); // 허용할 프론트엔드 도메인 nginx
         configuration.setAllowCredentials(true); // 쿠키 및 인증 정보를 포함한 요청 허용
         configuration.addAllowedMethod("*"); // 모든 HTTP 메서드 허용
         configuration.addAllowedHeader("*"); // 모든 헤더 허용

--- a/src/main/java/com/example/backend/controller/ReportController.java
+++ b/src/main/java/com/example/backend/controller/ReportController.java
@@ -47,4 +47,23 @@ public class ReportController {
             return null;
         }
     }
+
+    @GetMapping("/all")
+    public ResponseEntity<Map<String, Object>> getAllReport(
+            @AuthenticationPrincipal Long memberId,
+            @RequestParam YearMonth month
+    ) {
+        try {
+            Map<String, Map<String, Object>> reports = reportService.getAllReports(memberId, month);
+            return ResponseEntity.ok(Map.of("reports", reports));
+        } catch (IllegalArgumentException e) {
+            log.error("잘못된 요청: {}", e.getMessage());
+            return ResponseEntity.badRequest().body(Map.<String, Object>of("error", "잘못된 요청: " + e.getMessage()));
+        } catch (Exception e) {
+            log.error("보고서 생성 오류", e);
+            return ResponseEntity.status(500).body(Map.of("error", "보고서 생성 중 오류 발생"));
+        }
+    }
+
+
 }

--- a/src/main/java/com/example/backend/model/Report.java
+++ b/src/main/java/com/example/backend/model/Report.java
@@ -22,11 +22,20 @@ public class Report extends BaseTime{
     // 사업자 식별 번호
     @ManyToOne
     @JoinColumn(name = "business_registration_id", nullable = false)
-    private BusinessRegistration businessRegistrationId;
+    private BusinessRegistration businessRegistration;
 
     // 레포트 대상 월
     @Column(name = "report_month")
     private LocalDate reportMonth;
+
+    // 레포트 유형 (MARKET_REPORT, INDUSTRY_COMPARISON
+    @Column(name = "report_type", nullable = false, length = 50)
+    private String reportType;
+
+    // 보고서 내용 (JSON 형태)
+    @Lob
+    @Column(name="content", nullable = false, columnDefinition = "JSON")
+    private String content;
 
     // 해당 월의 매출 총액
     @Column(name = "revenue")


### PR DESCRIPTION
## 작업 번호
- 작업 번호: 

## 작업 내용
- 프론트에서 리포트 요청 시 리포트 2가지 한번에 호출 
- 리포트 호출 시 DB에서 조회
- 만약 리포트 내용이 DB에 없다면 API 자동 요청되어 content 생성 후 DB 저장